### PR TITLE
Handle no queue exists in requeue

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ All the functions are class methods
 rate_limited_enqueue(klass, *params)
 rate_limited_requeue(klass, *params)
 ````
-Queue the job specified to the resque queue specified by `@queue`. `rate_limited_requeue` is intended for use when you need the job to be pushed back to the queue; it just calls `rate_limited_queue`, but they are split to make testing with stubs easier.
+Queue the job specified to the resque queue specified by `@queue`. `rate_limited_requeue` is intended for use when you need the job to be pushed back to the queue; there are two reasons to split this from `queue`. Firstly it makes testing easier - secondly there is a boundary condition when you need to requeue the last job in the queue.
+`, but they are split to make testing with stubs easier.
 
 ```ruby
 pause

--- a/lib/resque-rate_limited_queue/version.rb
+++ b/lib/resque-rate_limited_queue/version.rb
@@ -1,3 +1,3 @@
 module RateLimitedQueue
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end


### PR DESCRIPTION
This fixes a case where a rate limit is hit while executing the last job in a queue.

Redis deletes the queue when it pulls off the last job, so the rename of the queue into the 'paused' state does nothing.

This is fine except the following `re_queue` then doesn't know which queue to send the job to, it defaulted to the main queue, and we get a busy wait as the job is re-tried and again hits the rate limit.

This code enhances `paused?` so you can specify what state you want to default to, and splits `queue` and `requeue`. For queue the default is to add to the main queue, worst case we'll hit a rate limit and call requeue.

For re-queue the default is to add to the paused queue.

Fixes https://github.com/pavoni/resque-rate_limited_queue/issues/4