### PR TITLE
Handle when queue is paused and Resque is inline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.ruby-gemset
+.ruby-version
 /.bundle/
 /.yardoc
 /Gemfile.lock

--- a/lib/resque-rate_limited_queue/version.rb
+++ b/lib/resque-rate_limited_queue/version.rb
@@ -1,3 +1,3 @@
 module RateLimitedQueue
-  VERSION = '1.0.2'
+  VERSION = '1.0.3'
 end

--- a/lib/resque/plugins/rate_limited_queue/rate_limited_queue.rb
+++ b/lib/resque/plugins/rate_limited_queue/rate_limited_queue.rb
@@ -57,7 +57,9 @@ module Resque
 
       def paused?(unknown = false)
         # parameter is what to return if the queue is empty, and so the state is unknown
-        if Resque.redis.exists(RESQUE_PREFIX + @queue.to_s)
+        if Resque.inline
+          false
+        elsif Resque.redis.exists(RESQUE_PREFIX + @queue.to_s)
           false
         elsif Resque.redis.exists(RESQUE_PREFIX + paused_queue_name)
           true

--- a/spec/rate_limited_queue_spec.rb
+++ b/spec/rate_limited_queue_spec.rb
@@ -118,6 +118,36 @@ describe Resque::Plugins::RateLimitedQueue do
     end
   end
 
+  describe 'when queue is paused and Resque is in inline mode' do
+    let(:resque_prefix) { Resque::Plugins::RateLimitedQueue::RESQUE_PREFIX }
+    let(:queue) { resque_prefix + RateLimitedTestQueue.queue_name_private }
+    let(:paused_queue) { resque_prefix + RateLimitedTestQueue.paused_queue_name }
+
+    before do
+      Resque.redis.stub(:exists).with(queue).and_return(false)
+      Resque.redis.stub(:exists).with(paused_queue).and_return(true)
+      Resque.inline = true
+    end
+
+    after do
+      Resque.inline = false
+    end
+
+    it 'would be paused' do
+      expect(Resque.redis.exists(queue)).to eq false
+      expect(Resque.redis.exists(paused_queue)).to eq true
+    end
+
+    it('says it is not paused') { expect(RateLimitedTestQueue.paused?).to eq false }
+
+    it 'performs the job' do
+      expect do
+        # Stack overflow unless handled
+        RateLimitedTestQueue.rate_limited_enqueue(RateLimitedTestQueue, true)
+      end.not_to raise_error
+    end
+  end
+
   describe 'find_class' do
     it 'works with symbol' do
       RateLimitedTestQueue.find_class(RateLimitedTestQueue).should eq RateLimitedTestQueue

--- a/spec/rate_limited_queue_spec.rb
+++ b/spec/rate_limited_queue_spec.rb
@@ -138,7 +138,9 @@ describe Resque::Plugins::RateLimitedQueue do
       expect(Resque.redis.exists(paused_queue)).to eq true
     end
 
-    it('says it is not paused') { expect(RateLimitedTestQueue.paused?).to eq false }
+    it 'says it is not paused' do
+      expect(RateLimitedTestQueue.paused?).to eq false
+    end
 
     it 'performs the job' do
       expect do


### PR DESCRIPTION
If the queue is paused but Resque is inline (`Resque.inline = true`) then enqueuing a job gets stuck in a loop. The job is enqueued to the paused queue, but Resque calls `perform` on it immediately when in inline mode. For rate-limited queue jobs this call to `perform` simply triggers it to be requeued back on the paused queue.

This is most likely to happen when running tests and in this situation the tests should be designed to explicitly manage Resque's `inline` setting and the RateLimitedQueue `paused` setting to prevent this happening.

I've taken the view that if an impossible combination of settings is attempted then we should perform the job inline.