### PR TITLE
Enqueue actual job so that ResqueSolo can manage it

### DIFF
--- a/lib/resque-rate_limited_queue/version.rb
+++ b/lib/resque-rate_limited_queue/version.rb
@@ -1,3 +1,3 @@
 module RateLimitedQueue
-  VERSION = '1.0.5'.freeze
+  VERSION = '1.1.0'.freeze
 end

--- a/lib/resque-rate_limited_queue/version.rb
+++ b/lib/resque-rate_limited_queue/version.rb
@@ -1,3 +1,3 @@
 module RateLimitedQueue
-  VERSION = '1.0.4'
+  VERSION = '1.0.4'.freeze
 end

--- a/lib/resque-rate_limited_queue/version.rb
+++ b/lib/resque-rate_limited_queue/version.rb
@@ -1,3 +1,3 @@
 module RateLimitedQueue
-  VERSION = '1.0.4'.freeze
+  VERSION = '1.0.5'.freeze
 end

--- a/lib/resque/plugins/rate_limited_queue/apis/base_api_queue.rb
+++ b/lib/resque/plugins/rate_limited_queue/apis/base_api_queue.rb
@@ -4,7 +4,8 @@ module Resque
       class BaseApiQueue
         extend Resque::Plugins::RateLimitedQueue
         def self.perform(klass, *params)
-          find_class(klass).perform(*params)
+          # find_class(klass).perform(*params)
+          Resque.enqueue_to @queue, klass, *params # Enqueue so that ResqueSolo can take effect
         end
 
         def self.enqueue(klass, *params)

--- a/lib/resque/plugins/rate_limited_queue/rate_limited_queue.rb
+++ b/lib/resque/plugins/rate_limited_queue/rate_limited_queue.rb
@@ -1,8 +1,8 @@
 module Resque
   module Plugins
     module RateLimitedQueue
-      RESQUE_PREFIX = 'queue:'
-      MUTEX = 'Resque::Plugins::RateLimitedQueue'
+      RESQUE_PREFIX = 'queue:'.freeze
+      MUTEX = 'Resque::Plugins::RateLimitedQueue'.freeze
 
       def around_perform_with_check_and_requeue(*params)
         paused = false

--- a/lib/resque/plugins/rate_limited_queue/rate_limited_un_pause.rb
+++ b/lib/resque/plugins/rate_limited_queue/rate_limited_un_pause.rb
@@ -18,7 +18,8 @@ module Resque
               @queue,
               timestamp,
               Resque::Plugins::RateLimitedQueue::UnPause,
-              klass)
+              klass
+            )
           end
 
           def perform(klass)

--- a/resque-rate_limited_queue.gemspec
+++ b/resque-rate_limited_queue.gemspec
@@ -30,14 +30,14 @@ and evernote; these allow you to support rate limited apis with minimal changes.
   spec.add_dependency 'evernote-thrift', '~> 1.25', '>= 1.25.1'
   spec.add_dependency 'twitter', '~> 5.11', '>= 5.11.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.7'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 2.6'
-  spec.add_development_dependency 'simplecov', '~> 0.9.1'
-  spec.add_development_dependency 'gem-release', '~> 0.7'
-  spec.add_development_dependency 'guard', '~> 2.12'
-  spec.add_development_dependency 'guard-rspec', '~> 4.1', '>= 4.1.1'
-  spec.add_development_dependency 'guard-rubocop', '~> 1.2'
-  spec.add_development_dependency 'parser', '~> 2.2.2.5' # To avoid Rubocop parser warnings
-  spec.add_development_dependency 'rubocop', '~> 0.32'
+  spec.add_development_dependency 'rake', '~> 10'
+  spec.add_development_dependency 'rspec', '~> 2'
+  spec.add_development_dependency 'simplecov', '~> 0'
+  spec.add_development_dependency 'rubocop', '~> 0'
+  spec.add_development_dependency 'reek', '~> 4'
+  spec.add_development_dependency 'listen', '~> 3.0', '< 3.1' # Dependency of guard, 3.1 requires Ruby 2.2+
+  spec.add_development_dependency 'guard', '~> 2'
+  spec.add_development_dependency 'guard-rspec', '~> 4'
+  spec.add_development_dependency 'guard-rubocop', '~> 1'
+  spec.add_development_dependency 'gem-release', '~> 0'
 end

--- a/spec/apis/angellist_queue_spec.rb
+++ b/spec/apis/angellist_queue_spec.rb
@@ -3,7 +3,7 @@ require 'resque/rate_limited_queue'
 
 class RateLimitedTestQueueAL
   def self.perform(succeed)
-    fail(AngellistApi::Error::TooManyRequests, 'error') unless succeed
+    raise(AngellistApi::Error::TooManyRequests, 'error') unless succeed
   end
 end
 
@@ -18,7 +18,8 @@ describe Resque::Plugins::RateLimitedQueue::AngellistQueue do
         :angellist_api,
         Resque::Plugins::RateLimitedQueue::AngellistQueue,
         RateLimitedTestQueueAL.to_s,
-        true)
+        true
+      )
       Resque::Plugins::RateLimitedQueue::AngellistQueue
         .enqueue(RateLimitedTestQueueAL, true)
     end

--- a/spec/apis/evernote_queue_spec.rb
+++ b/spec/apis/evernote_queue_spec.rb
@@ -9,7 +9,7 @@ end
 
 class RateLimitedTestQueueEn
   def self.perform(succeed)
-    fail(
+    raise(
       Evernote::EDAM::Error::EDAMSystemException,
       errorCode: Evernote::EDAM::Error::EDAMErrorCode::RATE_LIMIT_REACHED,
       rateLimitDuration: RateLimitDuration
@@ -19,7 +19,7 @@ end
 
 class RateLimitedTestQueueOther
   def self.perform
-    fail(Evernote::EDAM::Error::EDAMSystemException)
+    raise(Evernote::EDAM::Error::EDAMSystemException)
   end
 end
 
@@ -33,7 +33,8 @@ describe Resque::Plugins::RateLimitedQueue::EvernoteQueue do
         :evernote_api,
         Resque::Plugins::RateLimitedQueue::EvernoteQueue,
         RateLimitedTestQueueEn.to_s,
-        true)
+        true
+      )
       Resque::Plugins::RateLimitedQueue::EvernoteQueue
         .enqueue(RateLimitedTestQueueEn, true)
     end

--- a/spec/apis/twitter_queue_spec.rb
+++ b/spec/apis/twitter_queue_spec.rb
@@ -3,7 +3,7 @@ require 'resque/rate_limited_queue'
 
 class RateLimitedTestQueueTw
   def self.perform(succeed)
-    fail(Twitter::Error::TooManyRequests
+    raise(Twitter::Error::TooManyRequests
       .new('', 'x-rate-limit-reset' => (Time.now + 60).to_i)) unless succeed
   end
 end
@@ -19,7 +19,8 @@ describe Resque::Plugins::RateLimitedQueue::TwitterQueue do
         :twitter_api,
         Resque::Plugins::RateLimitedQueue::TwitterQueue,
         RateLimitedTestQueueTw.to_s,
-        true)
+        true
+      )
       Resque::Plugins::RateLimitedQueue::TwitterQueue
         .enqueue(RateLimitedTestQueueTw, true)
     end

--- a/spec/rate_limited_queue_spec.rb
+++ b/spec/rate_limited_queue_spec.rb
@@ -83,7 +83,7 @@ describe Resque::Plugins::RateLimitedQueue do
 
       it 'should schedule an unpause job' do
         Resque::Plugins::RateLimitedQueue::UnPause.should_receive(:enqueue)
-          .with(nil, 'RateLimitedTestQueue')
+                                                  .with(nil, 'RateLimitedTestQueue')
         RateLimitedTestQueue.pause_until(nil)
       end
     end

--- a/spec/rate_limited_un_pause_spec.rb
+++ b/spec/rate_limited_un_pause_spec.rb
@@ -28,7 +28,8 @@ describe Resque::Plugins::RateLimitedQueue::UnPause do
           :queue_name,
           nil,
           Resque::Plugins::RateLimitedQueue::UnPause,
-          RateLimitedTestQueue)
+          RateLimitedTestQueue
+        )
 
         Resque::Plugins::RateLimitedQueue::UnPause.enqueue(nil, RateLimitedTestQueue)
       end


### PR DESCRIPTION
This gem cannot assume the presence of a queue manager such as ResqueSolo, so the rate-limited jobs are enqueued regardless of uniqueness. When the underlying job is spooled, we now enqueue the job instead of performing it so that the underlying class's queue management features can be invoked.

Other changes are a result of Rubocop's latest preferences.
